### PR TITLE
Added rowMode and type to result

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,13 @@
 var Result = require('./pg').Result
 var prepare = require('./pg').prepareValue
 
-var Cursor = function(text, values) {
+var Cursor = function(text, values, cnf) {
   this.text = text
   this.values = values ? values.map(prepare) : null
   this.connection = null
   this._queue = []
   this.state = 'initialized'
-  this._result = new Result()
+  this._result = new Result(cnf.rowMode, cnf.types)
   this._cb = null
   this._rows = null
 }


### PR DESCRIPTION
I added the ability to set the rowMode and types for the internal Result. I needed use the rowMode="array" myself and already used it in the "pg" package itself. I just also needed it in your pg-cursor package. It turned out to be pretty straight forward.
