### PR TITLE
handle empty query

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,6 +89,12 @@ Cursor.prototype.handleReadyForQuery = function() {
   this.state = 'done'
 }
 
+Cursor.prototype.handleEmptyQuery = function(con) {
+  if (con.sync) {
+    con.sync()
+  }
+};
+
 Cursor.prototype.handleError = function(msg) {
   this.state = 'error'
   this._error = msg

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "author": "Brian M. Carlson",
   "license": "MIT",
   "devDependencies": {
-    "pg.js": "~3.4.4",
+    "pg": "~6.0.0",
     "mocha": "~1.17.1"
   },
   "dependencies": {}

--- a/test/close.js
+++ b/test/close.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 var Cursor = require('../')
-var pg = require('pg.js')
+var pg = require('pg')
 
 var text = 'SELECT generate_series as num FROM generate_series(0, 50)'
 describe('close', function() {

--- a/test/error-handling.js
+++ b/test/error-handling.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 var Cursor = require('../')
-var pg = require('pg.js')
+var pg = require('pg')
 
 var text = 'SELECT generate_series as num FROM generate_series(0, 4)'
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,6 @@
 var assert = require('assert')
 var Cursor = require('../')
-var pg = require('pg.js')
+var pg = require('pg')
 
 var text = 'SELECT generate_series as num FROM generate_series(0, 5)'
 

--- a/test/no-data-handling.js
+++ b/test/no-data-handling.js
@@ -1,5 +1,5 @@
 var assert = require('assert')
-var pg = require('pg.js');
+var pg = require('pg');
 var Cursor = require('../');
 
 describe('queries with no data', function () {
@@ -22,4 +22,15 @@ describe('queries with no data', function () {
       done()
     })
   });
+
+  it('handles empty query', function (done) {
+    var cursor = new Cursor('-- this is a comment')
+    cursor = this.client.query(cursor)
+    cursor.read(100, function (err, rows) {
+      assert.ifError(err)
+      assert.equal(rows.length, 0)
+      done()
+    })
+  })
+
 });


### PR DESCRIPTION
pg cursor previously crashed when handling an empty query. I lifted the solution from the pg library, and removed the prepared statement check. Tests have been updated to reference pg, tested with version 6. 