### PR TITLE
Fix require for webpack compatibility

### DIFF
--- a/pg.js
+++ b/pg.js
@@ -1,13 +1,10 @@
-var path = require('path')
-var pgPath;
 //support both pg & pg.js
 //this will eventually go away when i break native bindings
 //out into their own module
 try {
-  pgPath = path.dirname(require.resolve('pg'))
+  module.exports.Result = require('pg/lib/result.js')
+  module.exports.prepareValue = require('pg/lib/utils.js').prepareValue
 } catch(e) {
-  pgPath = path.dirname(require.resolve('pg.js')) + '/lib'
+  module.exports.Result = require('pg.js/lib/result.js')
+  module.exports.prepareValue = require('pg.js/lib/utils.js').prepareValue
 }
-
-module.exports.Result = require(path.join(pgPath, 'result.js'))
-module.exports.prepareValue = require(path.join(pgPath, 'utils.js')).prepareValue


### PR DESCRIPTION
Small change that might only impact me. I use webpack to package server-side stuff. It doesn't play well with require.resolve. This code accomplishes the same thing and plays nice with webpack.