### PR TITLE
Emit Query Events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,13 @@
 language: node_js
+dist: trusty
+sudo: false
 node_js:
   - "6"
 env:
   - PGUSER=postgres
+services:
+  - postgresql
+addons:
+  postgresql: "9.6"
+before_script:
+  - psql -c 'create database travis;' -U postgres | true

--- a/index.js
+++ b/index.js
@@ -115,7 +115,11 @@ Cursor.prototype.handleError = function(msg) {
   for(var i = 0; i < this._queue.length; i++) {
     this._queue.pop()[1](msg)
   }
-  this.emit('error', msg)
+
+  if (this.eventNames().indexOf('error') >= 0) {
+    //only dispatch error events if we have a listener
+    this.emit('error', msg)
+  }
   //call sync to keep this connection from hanging
   this.connection.sync()
 }

--- a/test/index.js
+++ b/test/index.js
@@ -127,4 +127,33 @@ describe('cursor', function() {
       done()
     })
   })
+
+  it('emits row events', function(done) {
+    var cursor = this.pgCursor(text)
+    cursor.read(10)
+    cursor.on('row', (row, result) => result.addRow(row))
+    cursor.on('end', (result) => {
+      assert.equal(result.rows.length, 6)
+      done()
+    })
+  })
+
+  it('emits row events when cursor is closed manually', function(done) {
+    var cursor = this.pgCursor(text)
+    cursor.on('row', (row, result) => result.addRow(row))
+    cursor.on('end', (result) => {
+      assert.equal(result.rows.length, 3)
+      done()
+    })
+
+    cursor.read(3, () => cursor.close())
+  })
+
+  it('emits error events', function(done) {
+    var cursor = this.pgCursor('select asdfasdf')
+    cursor.on('error', function(err) {
+      assert(err)
+      done()
+    })
+  })
 })


### PR DESCRIPTION
This change adds events to the `Cursor` object as per the [Query API](https://github.com/brianc/node-postgres/wiki/Query).

See https://github.com/brianc/node-pg-cursor/issues/24 for background and discussion.