### PR TITLE
Do not send close after readyForQuery

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,9 @@ Cursor.prototype.end = function(cb) {
 }
 
 Cursor.prototype.close = function(cb) {
+  if (this.state == 'done') {
+    return setImmediate(cb)
+  }
   this.connection.close({type: 'P'})
   this.connection.sync()
   this.state = 'done'

--- a/test/pool.js
+++ b/test/pool.js
@@ -1,0 +1,85 @@
+const assert = require('assert')
+const Cursor = require('../')
+const pg = require('pg')
+
+const text = 'SELECT generate_series as num FROM generate_series(0, 50)'
+
+function poolQueryPromise(pool, readRowCount) {
+  return new Promise((resolve, reject) => {
+    pool.connect((err, client, done) => {
+      if (err) {
+        done(err)
+        return reject(err)
+      }
+      const cursor = client.query(new Cursor(text))
+      cursor.read(readRowCount, (err, res) => {
+        if (err) {
+          done(err)
+          return reject(err)
+        }
+        cursor.close(err => {
+          if (err) {
+            done(err)
+            return reject(err)
+          }
+          done()
+          resolve()
+        })
+      })
+    })
+  })
+}
+
+describe('pool', function() {
+  beforeEach(function() {
+    this.pool = new pg.Pool({max: 1})
+  })
+
+  afterEach(function() {
+    this.pool.end()
+  })
+
+  it('closes cursor early, single pool query', function(done) {
+    poolQueryPromise(this.pool, 25)
+      .then(() => done())
+      .catch(err => {
+        assert.ifError(err)
+        done()
+      })
+  })
+
+  it('closes cursor early, saturated pool', function(done) {
+    const promises = []
+    for (let i = 0; i < 10; i++) {
+      promises.push(poolQueryPromise(this.pool, 25))
+    }
+    Promise.all(promises)
+      .then(() => done())
+      .catch(err => {
+        assert.ifError(err)
+        done()
+      })
+  })
+
+  it('closes exhausted cursor, single pool query', function(done) {
+    poolQueryPromise(this.pool, 100)
+      .then(() => done())
+      .catch(err => {
+        assert.ifError(err)
+        done()
+      })
+  })
+
+  it('closes exhausted cursor, saturated pool', function(done) {
+    const promises = []
+    for (let i = 0; i < 10; i++) {
+      promises.push(poolQueryPromise(this.pool, 100))
+    }
+    Promise.all(promises)
+      .then(() => done())
+      .catch(err => {
+        assert.ifError(err)
+        done()
+      })
+  })
+})


### PR DESCRIPTION
Close is used to release a named portal (which isn't used by pg-cursor) or when you're early-terminating a cursor on the unnamed portal. Sending 'close' on an connection which has already sent 'readyForQuery' results in the connection responding with a _second_ 'readyForQuery' which causes a lot of issues within node-postgres as 'readyForQuery' is the signal to indicate the client has gone back into the idle state.

This builds on and fixes #26 and closes #27.

/cc @rickbergfalk thank you __so much__ for the failing test as a pull request.  That is literally the best case PR scenario and makes my life so much easier! :dancer: 