### PR TITLE
Add support for rowMode & custom types

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
     "mocha": "^3.5.0",
-    "pg": "~6.0.0"
+    "pg": "6.x"
   },
   "dependencies": {}
 }

--- a/test/query-config.js
+++ b/test/query-config.js
@@ -31,6 +31,5 @@ describe('query config passed to result', () => {
       client.end()
       done()
     })
-
   })
 })

--- a/test/query-config.js
+++ b/test/query-config.js
@@ -1,0 +1,36 @@
+'use strict'
+const assert = require('assert')
+const Cursor = require('../')
+const pg = require('pg')
+
+describe('query config passed to result', () => {
+  it('passes rowMode to result', (done) => {
+    const client = new pg.Client()
+    client.connect()
+    const text = 'SELECT generate_series as num FROM generate_series(0, 5)'
+    const cursor = client.query(new Cursor(text, null, { rowMode: 'array' }))
+    cursor.read(10, (err, rows) => {
+      assert(!err)
+      assert.deepEqual(rows, [[0], [1], [2], [3], [4], [5]])
+      client.end()
+      done()
+    })
+  })
+
+  it('passes types to result', (done) => {
+    const client = new pg.Client()
+    client.connect()
+    const text = 'SELECT generate_series as num FROM generate_series(0, 2)'
+    const types = {
+      getTypeParser: () => () => 'foo'
+    }
+    const cursor = client.query(new Cursor(text, null, { types }))
+    cursor.read(10, (err, rows) => {
+      assert(!err)
+      assert.deepEqual(rows, [{ num: 'foo' }, { num: 'foo' }, { num: 'foo' }])
+      client.end()
+      done()
+    })
+
+  })
+})


### PR DESCRIPTION
This implements #16 with passing tests.  Adds support for passing a 3rd argument of query config parameters to the cursor.  The goal is to support the same parameters as the query config from node-postgres whenever it makes sense.