### PR TITLE
Add repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
   "scripts": {
     "test": " mocha && eslint ."
   },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/brianc/node-pg-cursor.git"
+  },
   "author": "Brian M. Carlson",
   "license": "MIT",
   "devDependencies": {


### PR DESCRIPTION
Without this pages like https://www.npmjs.com/package/pg-cursor don't link back correctly.